### PR TITLE
Do not expand unset variables or parameters

### DIFF
--- a/src/bats-mock.bash
+++ b/src/bats-mock.bash
@@ -68,7 +68,7 @@ EOF
 mock_set_status() {
   local mock="${1?'Mock must be specified'}"
   local status="${2?'Status must be specified'}"
-  local n="$3"
+  local n="${3-}"
 
   mock_set_property "${mock}" 'status' "${status}" "${n}"
 }
@@ -81,7 +81,7 @@ mock_set_status() {
 mock_set_output() {
   local mock="${1?'Mock must be specified'}"
   local output="${2?'Output must be specified'}"
-  local n="$3"
+  local n="${3-}"
 
   mock_set_property "${mock}" 'output' "${output}" "${n}"
 }
@@ -94,7 +94,7 @@ mock_set_output() {
 mock_set_side_effect() {
   local mock="${1?'Mock must be specified'}"
   local side_effect="${2?'Side effect must be specified'}"
-  local n="$3"
+  local n="${3-}"
 
   mock_set_property "${mock}" 'side_effect' "${side_effect}" "${n}"
 }
@@ -119,7 +119,7 @@ mock_get_call_num() {
 mock_get_call_user() {
   local mock="${1?'Mock must be specified'}"
   local n
-  n="$(mock_default_n ${mock} $2)" || exit "$?"
+  n="$(mock_default_n ${mock} ${2-})" || exit "$?"
 
   echo "$(cat ${mock}.user.${n})"
 }
@@ -133,7 +133,7 @@ mock_get_call_user() {
 mock_get_call_args() {
   local mock="${1?'Mock must be specified'}"
   local n
-  n="$(mock_default_n ${mock} $2)" || exit "$?"
+  n="$(mock_default_n ${mock} ${2-})" || exit "$?"
 
   echo "$(cat ${mock}.args.${n})"
 }
@@ -148,11 +148,11 @@ mock_get_call_args() {
 mock_get_call_env() {
   local mock="${1?'Mock must be specified'}"
   local var="${2?'Variable name must be specified'}"
-  local n="$3"
-  n="$(mock_default_n ${mock} $3)" || exit "$?"
+  local n
+  n="$(mock_default_n ${mock} ${3-})" || exit "$?"
 
   source "${mock}.env.${n}"
-  echo "${!var}"
+  echo "${!var-}"
 }
 
 # Sets a specific property of the mock
@@ -167,7 +167,7 @@ mock_set_property() {
   local mock="${1?'Mock must be specified'}"
   local property_name="${2?'Property name must be specified'}"
   local property_value="${3?'Property value must be specified'}"
-  local n="$4"
+  local n="${4-}"
 
   if [[ "${property_value}" = '-' ]]; then
     property_value="$(cat -)"

--- a/test/mock_create.bats
+++ b/test/mock_create.bats
@@ -1,5 +1,7 @@
 #!/usr/bin/env bats
 
+set -euo pipefail
+
 load ../src/bats-mock
 
 teardown() {

--- a/test/mock_test_suite.bash
+++ b/test/mock_test_suite.bash
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 load ../src/bats-mock
 
 setup() {


### PR DESCRIPTION
Use `${2-}` or `${!var-}` instead of `$2` or `${!var}` if parameters or indirect
expansions are optional.

Use `set -euo pipefail` in all tests to avoid regressions.